### PR TITLE
filtering targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ xcov -w LystSDK.xcworkspace -s LystSDK -o xcov_output
 * `--minimum_coverage_percentage` `-m`: Raise exception if overall coverage percentage is under this value (ie. 75).
 * `--include_test_targets`: Enables coverage reports for `.xctest` targets.
 * `--ignore_file_path` `-x`: Relative or absolute path to the file containing the list of ignored files.
+* `--exclude_targets`: Comma separated list of targets to exclude from coverage report.
 * `--slack_url` `-i`: Incoming WebHook for your Slack group to post results (optional).
 * `--slack_channel` `-e`: Slack channel where the results will be posted (optional).
 * `--skip_slack`: Add this flag to avoid publishing results on Slack (optional).

--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -44,15 +44,33 @@ module Xcov
     # Class methods
 
     def self.map dictionary
-      targets = dictionary["targets"].select { |target| !target["name"].include?(".xctest") }
 
-      # Don't filter test targets if the flag is set
-      targets = dictionary["targets"] if Xcov.config[:include_test_targets]
+      targets = self.filter_targets dictionary["targets"]
 
       # Create target objects
       targets = targets.map { |target| Target.map(target)}
 
       Report.new(targets)
+    end
+
+    def self.filter_targets targets
+
+      filtered_targets = Array.new(targets)
+      filtered_targets = filtered_targets.select { |target| !target["name"].include?(".xctest") } if !Xcov.config[:include_test_targets]
+      filtered_targets = filtered_targets.select { |target| !self.excluded_targets.include?(target["name"])}
+
+      return filtered_targets
+    end
+
+    def self.excluded_targets
+
+      excluded_targets = Array.new()
+
+      if Xcov.config[:exclude_targets]
+        excluded_targets = Xcov.config[:exclude_targets].split(/\W*,\W*/)
+      end
+
+      excluded_targets
     end
 
   end

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -77,7 +77,10 @@ module Xcov
         FastlaneCore::ConfigItem.new(key: :skip_slack,
                                      description: "Don't publish to slack, even when an URL is given",
                                      is_string: false,
-                                     default_value: false)
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :exclude_targets,
+                                     optional: true,
+                                     description: "Comma separated list of targets to exclude from coverage report")
       ]
     end
 


### PR DESCRIPTION
filtering targets by list of targets that user specifies with '--exclude_targets':

`xcov -w Workspace.xcworkspace -s "Scheme" --exclude_targets "SnapKit.framework"`

