### PR TITLE
Make JSON report honour ignored files in coverage

### DIFF
--- a/lib/xcov/model/function.rb
+++ b/lib/xcov/model/function.rb
@@ -18,6 +18,13 @@ module Xcov
       Function.template("function").result(binding)
     end
 
+    def json_value
+      {
+        "name" => @name,
+        "coverage" => @coverage,
+      }
+    end
+
     # Class methods
 
     def self.map (dictionary)

--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -45,6 +45,13 @@ module Xcov
       "#{@targets.map { |target| target.markdown_value }.join("")}\n> Powered by [xcov](https://github.com/nakiostudio/xcov)"
     end
 
+    def json_value
+        {
+          "coverage" => @coverage,
+          "targets" => @targets ? @targets.map{ |target| target.json_value } : []
+        }
+    end
+
     # Class methods
 
     def self.map dictionary

--- a/lib/xcov/model/source.rb
+++ b/lib/xcov/model/source.rb
@@ -45,6 +45,20 @@ module Xcov
       "#{@name} | `#{@displayable_coverage}` | #{coverage_emoji}\n"
     end
 
+    def json_value
+      value = {
+        "name" => @name,
+        "coverage" => @coverage,
+        "type" => @type,
+        "functions" => @functions ? @functions.map{ |function| function.json_value } : []
+      }
+      if @ignored then
+        value["ignored"] = true
+      end
+      return value
+    end
+
+
     # Class methods
 
     def self.map (dictionary)

--- a/lib/xcov/model/target.rb
+++ b/lib/xcov/model/target.rb
@@ -42,6 +42,14 @@ module Xcov
       markdown
     end
 
+    def json_value
+      {
+        "name" => @name,
+        "coverage" => @coverage,
+        "files" => @files ? @files.map{ |file| file.json_value } : []
+      }
+    end
+
     # Class methods
 
     def self.map (dictionary)

--- a/lib/xcov/runner.rb
+++ b/lib/xcov/runner.rb
@@ -70,7 +70,7 @@ module Xcov
       # Create JSON report
       if Xcov.config[:json_report] then
         File.open(File.join(output_path, "report.json"), "wb") do |file|
-          file.puts report_json.to_json
+          file.puts report.json_value.to_json
         end
       end
 


### PR DESCRIPTION
The current JSON report just spits out the raw report received
from xcov-core. As such, the coverage total, and the coverage
per target values in the JSON report are different from those in
the HTML or Markdown reports.

This patch creates a new JSON report using the same data that is
used for the HTML and Markdown reports. Targets which are skipped
(such as test targets) are not included in the output, and files
that have been ignored are marked with "ignored": true in the file
object and are not considered when calculating per target or per
report totals.