### PR TITLE
Display improvements for ignored files

### DIFF
--- a/lib/xcov/model/base.rb
+++ b/lib/xcov/model/base.rb
@@ -43,6 +43,8 @@ module Xcov
     end
 
     def coverage_emoji
+      return "" if @ignored
+
       if @coverage >= 0.80
         return ":white_check_mark:"
       elsif @coverage >= 0.50

--- a/lib/xcov/model/base.rb
+++ b/lib/xcov/model/base.rb
@@ -11,7 +11,7 @@ module Xcov
     attr_accessor :id
 
     def create_displayable_coverage
-      return "" if @ignored
+      return "-" if @ignored
 
       "%.0f%%" % [(@coverage*100)]
     end


### PR DESCRIPTION
In our project, ignored files show up in Github (via [danger-xcov](https://github.com/nakiostudio/danger-xcov)) like so:

<img width="394" alt="screen shot 2016-09-22 at 11 28 28" src="https://cloud.githubusercontent.com/assets/102904/18755079/ca42a23e-80b8-11e6-8608-b781e4655861.png">

The empty backticks in the coverage column are unfortunate, and I'm not sure it makes sense to display a coverage emoji for ignored files.

To that end:
- https://github.com/nakiostudio/xcov/commit/1e3cf4865dbc547debdbe813de568cb598ecb12b outputs a hyphen for ignored files' coverage, instead of an empty string. As noted in the commit message, a similar change (transforming an empty string to “-”) could instead be made in `markdown_value` in `source.rb`.
- https://github.com/nakiostudio/xcov/commit/08317ada2164419aece94972c4d7df4e84b51e83 should return an empty string instead of an emoji for ignored files.