### PR TITLE
Excluded targets option array support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+* Changed `exclude_targets` option so that it will also accept an array (by **tapi**)
+
 ### v.0.11.3
 * Fixed appearance of ignored files on markdown reports (by cdzombak).
 

--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -75,7 +75,11 @@ module Xcov
       excluded_targets = Array.new()
 
       if Xcov.config[:exclude_targets]
-        excluded_targets = Xcov.config[:exclude_targets].split(/\s*,\s*/)
+        if Xcov.config[:exclude_targets].is_a?(Array)
+          excluded_targets = Xcov.config[:exclude_targets]
+        else
+          excluded_targets = Xcov.config[:exclude_targets].split(/\s*,\s*/)
+        end
       end
 
       excluded_targets


### PR DESCRIPTION
When using xcov as a gem from something like Danger managing excluded targets as comma seperated string becomes cumbersome.

This change adds handling for when targets is passed in as an array it returns it directly, otherwise the behaviour is unchanged.
