### PR TITLE
Add include targets option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelog
 
+
 * Changed `exclude_targets` option so that it will also accept an array (by **tapi**)
+
+* Added `include_targets` option to limit reporting of targets to specific options (by **tapi**).
 
 ### v.0.11.3
 * Fixed appearance of ignored files on markdown reports (by cdzombak).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ xcov -w LystSDK.xcworkspace -s LystSDK -o xcov_output
 * `--include_test_targets`: Enables coverage reports for `.xctest` targets.
 * `--ignore_file_path` `-x`: Relative or absolute path to the file containing the list of ignored files.
 * `--exclude_targets`: Comma separated list of targets to exclude from coverage report.
+* `--include_targets`: Comma separated list of targets to include in coverage report.
 * `--slack_url` `-i`: Incoming WebHook for your Slack group to post results (optional).
 * `--slack_channel` `-e`: Slack channel where the results will be posted (optional).
 * `--html_report`: Enables the creation of a html report. Enabled by default (optional).

--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -66,7 +66,17 @@ module Xcov
     def self.filter_targets targets
       filtered_targets = Array.new(targets)
       filtered_targets = filtered_targets.select { |target| !target["name"].include?(".xctest") } if !Xcov.config[:include_test_targets]
-      filtered_targets = filtered_targets.select { |target| !self.excluded_targets.include?(target["name"])}
+
+      puts "Targets before filter #{filtered_targets.map { |target| target["name"] }}"
+      if Xcov.config[:exclude_targets]
+        filtered_targets = filtered_targets.select { |target| !self.excluded_targets.include?(target["name"])}
+      end
+
+      if Xcov.config[:include_targets]
+        filtered_targets = filtered_targets.select { |target| self.included_targets.include?(target["name"])}
+      end
+
+      puts "Targets after filter #{filtered_targets.map { |target| target["name"] }}"
 
       filtered_targets
     end
@@ -83,6 +93,20 @@ module Xcov
       end
 
       excluded_targets
+    end
+
+    def self.included_targets
+      included_targets = Array.new()
+
+      if Xcov.config[:include_targets]
+        if Xcov.config[:include_targets].is_a?(Array)
+          included_targets = Xcov.config[:include_targets]
+        else
+          included_targets = Xcov.config[:include_targets].split(/\s*,\s*/)
+        end
+      end
+
+      included_targets
     end
 
   end

--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -67,7 +67,6 @@ module Xcov
       filtered_targets = Array.new(targets)
       filtered_targets = filtered_targets.select { |target| !target["name"].include?(".xctest") } if !Xcov.config[:include_test_targets]
 
-      puts "Targets before filter #{filtered_targets.map { |target| target["name"] }}"
       if Xcov.config[:exclude_targets]
         filtered_targets = filtered_targets.select { |target| !self.excluded_targets.include?(target["name"])}
       end
@@ -75,8 +74,6 @@ module Xcov
       if Xcov.config[:include_targets]
         filtered_targets = filtered_targets.select { |target| self.included_targets.include?(target["name"])}
       end
-
-      puts "Targets after filter #{filtered_targets.map { |target| target["name"] }}"
 
       filtered_targets
     end

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -115,7 +115,12 @@ module Xcov
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :exclude_targets,
                                      optional: true,
-                                     description: "Comma separated list of targets to exclude from coverage report")
+                                     conflicting_options: [:include_targets],
+                                     description: "Comma separated list of targets to exclude from coverage report"),
+        FastlaneCore::ConfigItem.new(key: :include_targets,
+                                     optional: true,
+                                     conflicting_options: [:exclude_targets],
+                                     description: "Comma separated list of targets to include in coverage report")
       ]
     end
 

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -120,7 +120,7 @@ module Xcov
         FastlaneCore::ConfigItem.new(key: :include_targets,
                                      optional: true,
                                      conflicting_options: [:exclude_targets],
-                                     description: "Comma separated list of targets to include in coverage report")
+                                     description: "Comma separated list of targets to include in coverage report. If specified then exlude_targets will be ignored")
       ]
     end
 


### PR DESCRIPTION
With Xcode 8 it seems that coverage is generated for all targets in an app even it the schem for that target has coverage turned off.
When there are a lot of targets, for exampl projects that use cocoapods, an inclusion list is much easier to maintain than an exclusion list.

With this change a list of targets to include in the report can be specified as well as the exclusion list that existed previously.
