### PR TITLE
Verify 'derived_data_path' option

### DIFF
--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -39,7 +39,12 @@ module Xcov
                                      short_option: "-j",
                                      env_name: "XCOV_DERIVED_DATA_PATH",
                                      description: "The directory where build products and other derived data will go",
-                                     optional: true),
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       v = File.expand_path(value.to_s)
+                                       raise "Specified derived data directory does not exist".red unless File.exist?(v)
+                                       raise "Invalid derived data path, it must point to a directory".red unless File.directory?(v)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",
                                      env_name: "XCOV_OUTPUT_DIRECTORY",


### PR DESCRIPTION
If 'derived_data_path' argument was indicated but the path was inexistent,
we got this message:

> Unable to find any .xccoverage file.
> Make sure you have enabled 'Gather code coverage' setting on your scheme settings.
> Alternatively you can provide the full path to your .xccoverage file.

This patch adds a verification block to 'derived_data_path' option in
order to give faster and more accurate feedback.
