### PR TITLE
Compute 'source_directory' default value when requested

### DIFF
--- a/lib/xcov/ignore_handler.rb
+++ b/lib/xcov/ignore_handler.rb
@@ -54,7 +54,7 @@ module Xcov
     end
 
     def source_directory
-      Xcov.config[:source_directory]
+      Xcov.config[:source_directory] || Dir.pwd
     end
 
   end

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -40,7 +40,6 @@ module Xcov
                                      optional: true,
                                      env_name: "XCOV_SOURCE_DIRECTORY",
                                      description: "The path to project's root directory",
-                                     default_value: Dir.pwd,
                                      verify_block: proc do |value|
                                        v = File.expand_path(value.to_s)
                                        raise "Specified source directory does not exist".red unless File.exist?(v)


### PR DESCRIPTION
This change is made in order to fix a bug when 'xcov' gem is used
as a dependency and 'source_directory' is not explicitly defined.

This resolves #52.