### PR TITLE
Update gemspec to support fastlane 2.0

### DIFF
--- a/xcov.gemspec
+++ b/xcov.gemspec
@@ -21,13 +21,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane', '>= 2.0.0', '< 3.0.0'
+  spec.add_dependency 'fastlane', '>= 2.0.3', '< 3.0.0'
   spec.add_dependency 'slack-notifier', '~> 1.3'
   spec.add_dependency 'terminal-table' # print out build information
 
   # Development only
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "fastlane", ">= 1.90.0" # yes, we use fastlane for testing
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop", "~> 0.35.1"
   spec.add_development_dependency "rspec", "~> 3.1.0"

--- a/xcov.gemspec
+++ b/xcov.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.7', '< 1.0.0'
+  spec.add_dependency 'fastlane', '>= 2.0.0', '< 3.0.0'
   spec.add_dependency 'slack-notifier', '~> 1.3'
   spec.add_dependency 'terminal-table' # print out build information
 


### PR DESCRIPTION
With the recent [mono gem release](https://github.com/fastlane/fastlane/releases/tag/2.0.0) you'll need to remove _fastlane_core_ as dependency. 
Sorry I submitted this PR on such a short notice, I submitted PRs on various projects, but for some reasons I forgot to do it for this widely used one. 
Please give this a try with _fastlane_ 2.0, make sure everything works as usual and push a new release  👍
Thanks for building this!