### PR TITLE
Fix sorting files by coverage

### DIFF
--- a/lib/xcov/model/target.rb
+++ b/lib/xcov/model/target.rb
@@ -55,8 +55,7 @@ module Xcov
     def self.map (dictionary)
       name = dictionary["name"]
       files = dictionary["files"].map { |file| Source.map(file)}
-      files = files.sort! { |lhs, rhs| lhs.coverage <=> rhs.coverage }
-                   .sort! { |lhs, rhs| (lhs.ignored ? 1:0) <=> (rhs.ignored ? 1:0) }
+      files = files.sort &by_coverage_with_ignored_at_the_end
       coverage = Target.calculate_coverage(files)
 
       Target.new(name, coverage, files)
@@ -69,6 +68,19 @@ module Xcov
       coverage = coverage / non_ignored_files.count unless non_ignored_files.empty?
 
       coverage
+    end
+
+    def self.by_coverage_with_ignored_at_the_end
+      lambda { |lhs, rhs|
+        if lhs.ignored == rhs.ignored
+          # sort by coverage if files are both ignored
+          # or none of them are ignored
+          (lhs.coverage <=> rhs.coverage)
+        else
+          # ignored files will come at the end
+          (lhs.ignored ? 1:0) <=> (rhs.ignored ? 1:0)
+        end
+      }
     end
 
   end


### PR DESCRIPTION
Sorting by coverage got broken in v0.6 when support for ignored files was added.
This should return sorting behavior back keeping ignored files at the end of the list.

This resolves #61.