### PR TITLE
Handle ignores case insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Each one of the filenames you would like to ignore must be prefixed by the dash 
 - Carthage/Checkouts
 ```
 
+**Note:** Ignores are handled case-insensitively. `Pods` will match any of `pods`, `PODS`, or `Pods`.
+
 ### [Fastlane](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md)
 *Fastlane 1.61.0* includes *xcov* as a custom action. You can easily create your coverage reports as follows:
 ```ruby


### PR DESCRIPTION
As file system on macOS is case insensitive, we can ignore the cases
in order to prevent the situations when `test.txt` doesn't match `Test.txt`

This should prevent the kind of issues we had in #74.