### PR TITLE
Do not crash when missing lines for coveralls

### DIFF
--- a/lib/xcov/coveralls_handler.rb
+++ b/lib/xcov/coveralls_handler.rb
@@ -26,10 +26,13 @@ module Xcov
             next if file.ignored
 
             # Iterate through file lines
+
             lines = []
-            file.lines.each do |line|
-              lines << line.execution_count if line.executable
-              lines << nil unless line.executable
+            if !file.lines.nil?
+              file.lines.each do |line|
+                lines << line.execution_count if line.executable
+                lines << nil unless line.executable
+              end
             end
 
             relative_path = file.location


### PR DESCRIPTION
Partially fixes #116

The fix makes it not crash, but doesn't fix the source of the problem. `lines` is always nil when using the new `xccovreport` files.