### PR TITLE
Add option to disable automatic Coveralls submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ xcov -w LystSDK.xcworkspace -s LystSDK -o xcov_output
 * `--markdown_report`: Enables the creation of a markdown report (optional).
 * `--skip_slack`: Add this flag to avoid publishing results on Slack (optional).
 * `--only_project_targets`: Display the coverage only for main project targets (e.g. skip Pods targets).
-* `--coveralls_enabled`: If you want to use Coveralls support, this option must be enabled (optional).
+* `--disable_coveralls`: Add this flag to disable automatic submission to Coveralls.
 * `--coveralls_service_name`: Name of the CI service compatible with Coveralls. i.e. travis-ci. This option must be defined along with coveralls_service_job_id (optional).
 * `--coveralls_service_job_id`: Name of the current job running on a CI service compatible with Coveralls. This option must be defined along with coveralls_service_name (optional).
 * `--coveralls_repo_token`: Repository token to be used by integrations not compatible with Coveralls (optional).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ xcov -w LystSDK.xcworkspace -s LystSDK -o xcov_output
 * `--markdown_report`: Enables the creation of a markdown report (optional).
 * `--skip_slack`: Add this flag to avoid publishing results on Slack (optional).
 * `--only_project_targets`: Display the coverage only for main project targets (e.g. skip Pods targets).
+* `--coveralls_enabled`: If you want to use Coveralls support, this option must be enabled (optional).
 * `--coveralls_service_name`: Name of the CI service compatible with Coveralls. i.e. travis-ci. This option must be defined along with coveralls_service_job_id (optional).
 * `--coveralls_service_job_id`: Name of the current job running on a CI service compatible with Coveralls. This option must be defined along with coveralls_service_name (optional).
 * `--coveralls_repo_token`: Repository token to be used by integrations not compatible with Coveralls (optional).

--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -132,7 +132,7 @@ module Xcov
     end
 
     def submit_to_coveralls(report)
-      if !Xcov.config[:coveralls_enabled]
+      if Xcov.config[:disable_coveralls]
         return
       end
       if !Xcov.config[:coveralls_repo_token].nil? || !(Xcov.config[:coveralls_service_name].nil? && Xcov.config[:coveralls_service_job_id].nil?)

--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -132,6 +132,9 @@ module Xcov
     end
 
     def submit_to_coveralls(report)
+      if !Xcov.config[:coveralls_enabled]
+        return
+      end
       if !Xcov.config[:coveralls_repo_token].nil? || !(Xcov.config[:coveralls_service_name].nil? && Xcov.config[:coveralls_service_job_id].nil?)
         CoverallsHandler.submit(report)
       end

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -190,6 +190,14 @@ module Xcov
 
         # Coveralls options
         FastlaneCore::ConfigItem.new(
+          key: :coveralls_enabled,
+          env_name: "COVERALLS_ENABLED",
+          default_value: false,
+          optional: true,
+          is_string: false,
+          description: "Coveralls will not run without this option enabled"
+        ),
+        FastlaneCore::ConfigItem.new(
           key: :coveralls_service_name,
           env_name: "COVERALLS_SERVICE_NAME",
           optional: true,

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -190,12 +190,12 @@ module Xcov
 
         # Coveralls options
         FastlaneCore::ConfigItem.new(
-          key: :coveralls_enabled,
-          env_name: "COVERALLS_ENABLED",
+          key: :disable_coveralls,
+          env_name: "DISABLE_COVERALLS",
           default_value: false,
+          type: Boolean,
           optional: true,
-          is_string: false,
-          description: "Coveralls will not run without this option enabled"
+          description: "Add this flag to disable automatic submission to Coveralls."
         ),
         FastlaneCore::ConfigItem.new(
           key: :coveralls_service_name,


### PR DESCRIPTION
I was having an issue where Coveralls was being submitted automatically due to the presence of the environmental variables. This breaks backwards compatibility if you were relying on the automatic assumption of Coveralls via the environment, but I personally feel like being explicit is better.