### PR TITLE
Hotfix for "disable coveralls" PR

### DIFF
--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -195,7 +195,7 @@ module Xcov
           key: :disable_coveralls,
           env_name: "DISABLE_COVERALLS",
           default_value: false,
-          type: Boolean,
+          is_string: false,
           optional: true,
           description: "Add this flag to disable automatic submission to Coveralls."
         ),

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -197,7 +197,7 @@ module Xcov
           default_value: false,
           is_string: false,
           optional: true,
-          description: "Add this flag to disable automatic submission to Coveralls."
+          description: "Add this flag to disable automatic submission to Coveralls"
         ),
         FastlaneCore::ConfigItem.new(
           key: :coveralls_service_name,


### PR DESCRIPTION
Yikes, found some problems with #118. Looks like the xcov / fastlane options parser doesn't accept the "type" parameter for some reason, although I've used it elsewhere in a recent fastlane plugin, and complains about the "." in the description.