### PR TITLE
Quote file path passing to `git hash-object` command

### DIFF
--- a/lib/xcov/coveralls_handler.rb
+++ b/lib/xcov/coveralls_handler.rb
@@ -93,7 +93,7 @@ module Xcov
       end
 
       def digest_for_file(file_path)
-        hash = `git hash-object #{file_path}`
+        hash = `git hash-object "#{file_path}"`
         hash.delete!("\n")
         return hash
       end


### PR DESCRIPTION
Hi,

I found Coveralls handler outputs external command error like the below

```
fatal: Cannot open 'CI2Go/View': No such file or directory
```

ref: https://circleci.com/gh/ngs/ci2go/785

This happens project code contains folders with spaces.

So I double-quoted file path passing to `git hash-object` command.

Please merge this if you'd like.

Thanks,