### PR TITLE
#145: ArgumentError: [!] incomplete format specifier; use %% (double %) instead

### DIFF
--- a/lib/xcov/manager.rb
+++ b/lib/xcov/manager.rb
@@ -126,7 +126,7 @@ module Xcov
       # Raise exception if overall coverage is under threshold
       minimumPercentage = Xcov.config[:minimum_coverage_percentage] / 100
       if minimumPercentage > report.coverage
-        error_message = "Actual Code Coverage (#{"%.2f%" % (report.coverage*100)}) below threshold of #{"%.2f%" % (minimumPercentage*100)}"
+        error_message = "Actual Code Coverage (#{"%.2f%%" % (report.coverage*100)}) below threshold of #{"%.2f%%" % (minimumPercentage*100)}"
         ErrorHandler.handle_error_with_custom_message("CoverageUnderThreshold", error_message)
       end
     end


### PR DESCRIPTION
xcov ruby 2.6.0 issue: ArgumentError: [!] incomplete format specifier; use %% (double %) instead

Replace % to %% (double %) in error message