### PR TITLE
Allow using path from another runner's environment

### DIFF
--- a/lib/xcov/ignore_handler.rb
+++ b/lib/xcov/ignore_handler.rb
@@ -52,7 +52,8 @@ module Xcov
     def relative_path path
       require 'pathname'
 
-      full_path = Pathname.new(path).realpath             # /full/path/to/project/where/is/file.extension
+      full_path = Pathname.new(path)
+      full_path = full_path.absolute? ? full_path : full_path.realpath # /full/path/to/project/where/is/file.extension
       base_path = Pathname.new(source_directory).realpath # /full/path/to/project/
 
       full_path.relative_path_from(base_path).to_s        # where/is/file.extension


### PR DESCRIPTION
When tests are run on a runner other than the one on which the application was built, .xcresult file contains non-existent paths. Then the xcov crashes at 55 line with "No such file or directory @ rb_check_realpath_internal - /absolute/path/to/file" error. The patch allows not to check file existence if absolute path was provided. Yet we do expect existence of the file if relative path was provided.