### PR TITLE
build: dump out dirty files during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,9 @@ jobs:
           bundler-cache: true
           ruby-version: 3.2
 
-      - name: Install dependencies
-        run: bundle check || bundle install --jobs=4 --retry=3
+      - name: Debug git status
+        run: |
+          git status
+          git status --porcelain
 
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
* We already installed dependencies prior.
* Build failed due to dirty files. I don't replicate locally, so need to see what they are.

```
bundle exec rake release
xcov 1.9.0 built to pkg/xcov-1.9.0.gem.
rake aborted!
There are files that need to be committed first.
```