### PR TITLE
build: ignore changes to .bundle/config during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ignore changes to .bundle/config
+        run: git update-index --skip-worktree .bundle/config
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
As `setup-ruby` runs it touches our `.bundle/config` to inject some flags to ease cache creation. This makes a change and then the release process believes files are dirty. This is isolated to CI process, so we will skip that file during CI.